### PR TITLE
Addition of showTotal option and small colour tweak

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var prettyBytes = require('pretty-bytes');
 module.exports = function (options) {
 	options = options || {};
 
+	if (typeof options.showTotal === 'undefined' || options.showTotal === null) {
+		options.showTotal = true;
+	}
+
 	var totalSize = 0;
 
 	return through.obj(function (file, enc, cb) {
@@ -29,7 +33,10 @@ module.exports = function (options) {
 		this.push(file);
 		cb();
 	}, function (cb) {
-		gutil.log('gulp-size: ' + gutil.colors.green('total ') + prettyBytes(totalSize));
+		if (options.showTotal === true) {
+			gutil.log('gulp-size: ' + gutil.colors.green('total ') + prettyBytes(totalSize));
+		}
+
 		cb();
 	});
 };


### PR DESCRIPTION
This is a really small tweak to add the option of hiding the total size when outputting only one file. I saw a comment about this already but without any pull requests. I also changed the colour from blue to yellow for legibility.
