### PR TITLE
added an option to not automatically print the size

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ module.exports = function (opts) {
 		var title = opts.title;
 		title = title ? chalk.cyan(title) + ' ' : '';
 		size = opts.pretty !== false ? prettyBytes(size) : (size + ' B');
-		gutil.log(title + what + ' ' + chalk.magenta(size) + (opts.gzip ? chalk.gray(' (gzipped)') : ''));
+		if (typeof opts.quiet === 'undefined' || !opts.quiet) {
+			gutil.log(title + what + ' ' + chalk.magenta(size) + (opts.gzip ? chalk.gray(' (gzipped)') : ''));
+		}
 	}
 
 	return through.obj(function (file, enc, cb) {

--- a/readme.md
+++ b/readme.md
@@ -36,42 +36,49 @@ gulp.task('default', function () {
 
 ##### showFiles
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Displays the size of every file instead of just the total size.
 
 ##### gzip
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Displays the gzipped size instead.
 
 ##### title
 
-Type: `string`  
+Type: `string`
 Default: ''
 
 Give it a title so it's possible to distinguish the output of multiple instances logging at once.
 
 ##### pretty
 
-Type: `boolean`  
+Type: `boolean`
 Default: true
 
 Displays prettified size: `1337 B` → `1.34 kB`.
 
+##### quiet
+
+Type: `boolean`
+Default: false
+
+Will only track size, you will be responsible for printing it.
+
 ### size.size
 
-Type: `number`  
+Type: `number`
 Example: `12423000`
 
 The total size of all files in bytes.
 
 ### size.prettySize
 
-Type: `string`  
+Type: `string`
 Example: `'14 kB'`
 
 Prettified version of `.size`.


### PR DESCRIPTION
Added an option called quiet to not automatically print the size, for use with gulp-notify or something else that is reporting the size instead.