### PR TITLE
Allow supress 'all files' output

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = function (opts) {
 		this.size = totalSize;
 		this.prettySize = prettyBytes(totalSize);
 
-		if (!(fileCount === 1 && opts.showFiles) && totalSize > 0 && fileCount > 0) {
+		if (!(fileCount === 1 && opts.showFiles) && totalSize > 0 && fileCount > 0 && opts.showTotal !== false) {
 			log(chalk.green('all files'), totalSize);
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,8 @@ gulp.task('default', function () {
 Type: `boolean`  
 Default: `false`
 
-Displays the size of every file instead of just the total size.
+Displays the size of every file instead of just the total size (see also `showTotal`).
+
 
 ##### gzip
 
@@ -61,6 +62,13 @@ Type: `boolean`
 Default: true
 
 Displays prettified size: `1337 B` → `1.34 kB`.
+
+##### showTotal
+
+Type: `boolean`  
+Default: `true`
+
+Displays the total of all files. Useful, for example, if writing source files and source-map files in one operation.
 
 ### size.size
 


### PR DESCRIPTION
...with { showTotal: false } option.

This was proposed as part of #5 but the particular change was rejected with the question of 'why?'. It has been common (for me) on projects to want to build multiple files in a pipe but for the total of those files to be inconsequential, the output of which makes the logging unclear.

It's an option directly related to the functionality of this package, does not create any dependencies and does not change the default behavior, so I'm hoping it will be accepted.

Thanks