### PR TITLE
Added 'passthrough' option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = options => {
 	options = {
 		pretty: true,
 		showTotal: true,
+    passthrough: false,
 		...options
 	};
 
@@ -21,7 +22,9 @@ module.exports = options => {
 		let {title} = options;
 		title = title ? chalk.cyan(title) + ' ' : '';
 		size = options.pretty ? prettyBytes(size) : (size + ' B');
-		fancyLog(title + what + ' ' + chalk.magenta(size) + (options.gzip ? chalk.gray(' (gzipped)') : ''));
+    if(options.passthrough === false) {
+      fancyLog(title + what + ' ' + chalk.magenta(size) + (options.gzip ? chalk.gray(' (gzipped)') : ''));
+    }
 	}
 
 	return through.obj((file, encoding, callback) => {
@@ -38,7 +41,7 @@ module.exports = options => {
 
 			totalSize += size;
 
-			if (options.showFiles === true && size > 0) {
+			if (options.showFiles === true && size > 0 && options.passthrough === false) {
 				log(chalk.blue(file.relative), size);
 			}
 
@@ -79,7 +82,7 @@ module.exports = options => {
 		this.size = totalSize;
 		this.prettySize = prettyBytes(totalSize);
 
-		if (!(fileCount === 1 && options.showFiles) && totalSize > 0 && fileCount > 0 && options.showTotal) {
+		if (!(fileCount === 1 && options.showFiles) && totalSize > 0 && fileCount > 0 && options.showTotal && options.passthrough === false) {
 			log(chalk.green('all files'), totalSize);
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,13 @@ Default: `true`
 
 Displays the total of all files.
 
+##### passthrough
+
+Type: `boolean`<br>
+Default: `false`
+
+Disables output from gulp-size, values are left available to other Gulp plugins for use.
+
 ### size.size
 
 Type: `number`<br>


### PR DESCRIPTION
Disables output from gulp-size, but the values are still available to other plugins (my use case is with gulp-notify).

If approved, can you please update the version on NPM?