### PR TITLE
Fix error caused by the absence of files when starting gulp task

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,10 +112,9 @@ module.exports = (options = {}) => {
 		})();
 	}, function (callback) {
 		this.size = totalSize.values().next().value;
-		if (this.size){
+		if (this.size) {
 			this.prettySize = prettyBytes(this.size);
 		}
-
 
 		if (!(fileCount === 1 && options.showFiles) && hasSize(totalSize) && fileCount > 0 && options.showTotal) {
 			log(chalk.green('all files'), totalSize);

--- a/index.js
+++ b/index.js
@@ -112,7 +112,10 @@ module.exports = (options = {}) => {
 		})();
 	}, function (callback) {
 		this.size = totalSize.values().next().value;
-		this.prettySize = prettyBytes(this.size);
+		if (this.size){
+			this.prettySize = prettyBytes(this.size);
+		}
+
 
 		if (!(fileCount === 1 && options.showFiles) && hasSize(totalSize) && fileCount > 0 && options.showTotal) {
 			log(chalk.green('all files'), totalSize);

--- a/index.js
+++ b/index.js
@@ -111,8 +111,8 @@ module.exports = (options = {}) => {
 			}
 		})();
 	}, function (callback) {
-		this.size = totalSize.values().next().value;
-		this.prettySize = prettyBytes(this.size || 0);
+		this.size = totalSize.values().next().value || 0;
+		this.prettySize = prettyBytes(this.size);
 
 		if (!(fileCount === 1 && options.showFiles) && hasSize(totalSize) && fileCount > 0 && options.showTotal) {
 			log(chalk.green('all files'), totalSize);

--- a/index.js
+++ b/index.js
@@ -112,9 +112,7 @@ module.exports = (options = {}) => {
 		})();
 	}, function (callback) {
 		this.size = totalSize.values().next().value;
-		if (this.size) {
-			this.prettySize = prettyBytes(this.size);
-		}
+		this.prettySize = prettyBytes(this.size || 0);
 
 		if (!(fileCount === 1 && options.showFiles) && hasSize(totalSize) && fileCount > 0 && options.showTotal) {
 			log(chalk.green('all files'), totalSize);

--- a/index.js
+++ b/index.js
@@ -112,7 +112,9 @@ module.exports = (options = {}) => {
 		})();
 	}, function (callback) {
 		this.size = totalSize.values().next().value;
-		this.prettySize = prettyBytes(this.size);
+		if (this.size) {
+			this.prettySize = prettyBytes(this.size);
+		}
 
 		if (!(fileCount === 1 && options.showFiles) && hasSize(totalSize) && fileCount > 0 && options.showTotal) {
 			log(chalk.green('all files'), totalSize);


### PR DESCRIPTION
If there are no files in the folder, then task
.pipe (size ({
'gzip': true,
'pretty': true,
'showFiles': true,
'showTotal': true
}))
gives an error message

TypeError: Expected a finite number, got undefined: undefined
    at module.exports (W: \ Freelance \ Easy-webdev-startpack \ node_modules \ pretty-bytes \ index.js: 70: 9)
    at Transform._flush (W: \ Freelance \ Easy-webdev-startpack \ node_modules \ gulp-size \ index.js: 115: 21).

This fix solves this error, allowing you not to write additional functionality (in the form of disabling tasks if the folder with files is empty).

Thanks for attention!

Link to the task on which the error is caused: https://github.com/budfy/Easy-webdev-startpack/commit/50ad1fe865cc240bb1552fcac04208ee9d626bf1#diff-6e5c91cb2762eb968b4beffd0b5f42b94a46c4b6b5400195cb64ed98787a09a2